### PR TITLE
stereo proc seems to require image_raw as input

### DIFF
--- a/urdfs/sensors/multisense_sl.gazebo.xacro
+++ b/urdfs/sensors/multisense_sl.gazebo.xacro
@@ -116,7 +116,7 @@
 				<alwaysOn>true</alwaysOn>
 				<updateRate>0.0</updateRate>
                 <cameraName>${prefix}/camera</cameraName>
-                <imageTopicName>image_color</imageTopicName>
+                <imageTopicName>image_raw</imageTopicName>
                 <cameraInfoTopicName>camera_info</cameraInfoTopicName>
                 <frameName>${prefix}/left_camera_optical_frame</frameName>
                 <rightFrameName>${prefix}/right_camera_optical_frame</rightFrameName>


### PR DESCRIPTION
... when stereo proc is in a terminal it complains that it hasn't received image_raw. 

without this change it produces no output point clouds.

(FYI: stereo proc is invoked in upload.launch)