### PR TITLE
set noise stdev to zero

### DIFF
--- a/urdfs/sensors/multisense_sl.gazebo.xacro
+++ b/urdfs/sensors/multisense_sl.gazebo.xacro
@@ -47,7 +47,12 @@
 						stddev of 0.01m will put 99.7% of samples within 0.03m of the true
 						reading. -->
 						<mean>0.0</mean>
-						<stddev>0.01</stddev>
+            <!-- mfallon: if stddev > 0, points at max range e.g. 30m
+            (i.e. returns not observing anything) will return less than max
+            range e.g. 29.8m. This then messes up the laser filter chain.
+            this seems to be fixed in more recent versions of gazebo
+            -->
+						<stddev>0.0</stddev>
 					</noise>
 				</ray>
 				<plugin name="${prefix}/head_hokuyo_controller" filename="libgazebo_ros_gpu_laser.so">


### PR DESCRIPTION
if stddev > 0, points at max range e.g. 30m (i.e. returns not observing anything) will return less than max range e.g. 29.8m. This then messes up the laser filter chain.
Example of effect in rviz:
https://www.dropbox.com/s/zkfntclervrbu41/gazebo-noise-lidar-issue.ogv?dl=0

this seems to be fixed in more recent versions of gazebo:
https://bitbucket.org/osrf/gazebo/src/bae84f76b4ad7a6a7cecaeb3e76e545b8c8d5f3e/gazebo/sensors/RaySensor.cc?at=default&fileviewer=file-view-default